### PR TITLE
Make Seq class public

### DIFF
--- a/src-java/me/tonsky/persistent_sorted_set/Seq.java
+++ b/src-java/me/tonsky/persistent_sorted_set/Seq.java
@@ -4,7 +4,7 @@ import java.util.*;
 import clojure.lang.*;
 
 @SuppressWarnings("unchecked")
-class Seq extends ASeq implements IReduce, Reversible, IChunkedSeq, ISeek{
+public class Seq extends ASeq implements IReduce, Reversible, IChunkedSeq, ISeek{
   final PersistentSortedSet _set;
   Seq   _parent;
   ANode _node;


### PR DESCRIPTION
Just small followup to my changes. This would allow to check for `Seq` instances. Something like the following currently fails.
```clj
(instance? me.tonsky.persistent_sorted_set.Seq 'foo)
;; => Execution error (IllegalAccessError) at user/eval9344 (REPL:21).
;;    failed to access class me.tonsky.persistent_sorted_set.Seq from class user$eval9344 (me.tonsky.persistent_sorted_set.Seq is in unnamed module of loader 'app'; user$eval9344 is in unnamed module of loader clojure.lang.DynamicClassLoader @2782b1ce)
```